### PR TITLE
Shazam Search and Queue through Spotify

### DIFF
--- a/the-modern-jukebox-react-app/src/hooks/shazam.tsx
+++ b/the-modern-jukebox-react-app/src/hooks/shazam.tsx
@@ -3,7 +3,6 @@ export async function searchShazam(searchTerm?: string): Promise<any[]> {
     if(!searchTerm) {
         return [];
     }
-    
     const url = `https://shazam.p.rapidapi.com/search?term=${encodeURIComponent(searchTerm)}&locale=en-US&offset=0&limit=5`;
 
     // options for the fetch request

--- a/the-modern-jukebox-react-app/src/hooks/shazam.tsx
+++ b/the-modern-jukebox-react-app/src/hooks/shazam.tsx
@@ -1,5 +1,9 @@
 // function to search Shazam for a song
-export async function searchShazam(searchTerm: string): Promise<any[]> {
+export async function searchShazam(searchTerm?: string): Promise<any[]> {
+    if(!searchTerm) {
+        return [];
+    }
+    
     const url = `https://shazam.p.rapidapi.com/search?term=${encodeURIComponent(searchTerm)}&locale=en-US&offset=0&limit=5`;
 
     // options for the fetch request

--- a/the-modern-jukebox-react-app/src/hooks/shazam.tsx
+++ b/the-modern-jukebox-react-app/src/hooks/shazam.tsx
@@ -25,7 +25,7 @@ export async function searchShazam(searchTerm: string): Promise<any[]> {
         // get the response data
         const responseData = await response.json();
         const tracks = responseData.tracks.hits.map((hit: any) => hit.track);
-        console.log('Shazam search results:', tracks);
+        // console.log('Shazam search results:', tracks);
         return tracks;
 
     } catch (error) {

--- a/the-modern-jukebox-react-app/src/hooks/shazam.tsx
+++ b/the-modern-jukebox-react-app/src/hooks/shazam.tsx
@@ -1,5 +1,5 @@
 // function to search Shazam for a song
-export async function searchShazam(searchTerm?: string): Promise<any[]> {
+export async function searchShazam(searchTerm: string): Promise<any[]> {
     if(!searchTerm) {
         return [];
     }

--- a/the-modern-jukebox-react-app/src/hooks/spotify.tsx
+++ b/the-modern-jukebox-react-app/src/hooks/spotify.tsx
@@ -77,58 +77,39 @@ export const getTrackFromUri = async (uri: string) => {
   }
 };
 
-export async function searchSpotify(searchTerm: string): Promise<any[]> {
-  if(!searchTerm) {
-      return [];
+export async function searchSpotify(trackName: string, trackArtist: string): Promise<any[]> {
+  if (!trackName && !trackArtist) {
+    return [];
   }
 
   // get user token
-  let token = (sessionStorage.getItem("token")|| "")
+  let token = sessionStorage.getItem("token") || "";
 
-  // get data with axios
-  const {data} = await axios.get("https://api.spotify.com/v1/search",{
-      headers:{
-        Authorization:`Bearer ${token}`
-      },
-      params:{
-        q:searchTerm,
-        limit:6,
-        type: "track"
-      }
-  })
+  // define req url
+  const url = `https://api.spotify.com/v1/search?q=${encodeURIComponent(`remaster track:${trackName} artist:${trackArtist}`)}&type=track`;
 
-  const mappedData = data.tracks.items.map(
-    (track: {
-      name: "";
-      uri: "";
-      duration_ms: "";
-      album: {
-        name: "";
-        artists: [
-          {
-            name: "";
-          }
-        ];
-        images: [
-          {
-            url: "";
-          }
-        ];
-      };
-    }) => {
-      return {
-        name: track.name,
-        uri: track.uri,
-        duration_ms: track.duration_ms,
-        images: track.album.images[0].url,
-        albumName: track.album.name,
-        artistName: track.album.artists[0].name,
-      };
-    }
-  ) || {};
+  // define options
+  const options = {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
 
-  return mappedData;
+  try {
+    // make the fetch request
+    const response = await fetch(url, options);
 
+    // get the response data
+    const responseData = await response.json();
+    const tracks = responseData.tracks.hits.map((hit: any) => hit.track);
+    console.log('Spotify search results:', tracks);
+    return tracks;
+  } catch (error) {
+    // log any errors
+    console.error('Error during Spotify search:', error);
+    return [];
+  }
 }
 
 export {}

--- a/the-modern-jukebox-react-app/src/hooks/spotify.tsx
+++ b/the-modern-jukebox-react-app/src/hooks/spotify.tsx
@@ -77,7 +77,7 @@ export const getTrackFromUri = async (uri: string) => {
   }
 };
 
-export async function searchSpotify(trackName: string, trackArtist: string): Promise<any[]> {
+export async function searchSpotify(trackName: string, trackArtist: string): Promise<any> {
   if (!trackName && !trackArtist) {
     return [];
   }
@@ -104,7 +104,7 @@ export async function searchSpotify(trackName: string, trackArtist: string): Pro
     const responseData = await response.json();
     const track = responseData.tracks.items[0];
     console.log('Spotify search result:', track);
-    return [track];
+    return track;
   } catch (error) {
     // log any errors
     console.error('Error during Spotify search:', error);

--- a/the-modern-jukebox-react-app/src/hooks/spotify.tsx
+++ b/the-modern-jukebox-react-app/src/hooks/spotify.tsx
@@ -103,7 +103,7 @@ export async function searchSpotify(trackName: string, trackArtist: string): Pro
     // get the response data
     const responseData = await response.json();
     const track = responseData.tracks.items[0];
-    console.log('Spotify search result:', track);
+    // console.log('Spotify search result:', track);
     return track;
   } catch (error) {
     // log any errors

--- a/the-modern-jukebox-react-app/src/hooks/spotify.tsx
+++ b/the-modern-jukebox-react-app/src/hooks/spotify.tsx
@@ -77,6 +77,7 @@ export const getTrackFromUri = async (uri: string) => {
   }
 };
 
+// function used to make a GET req to spotify for searching
 export async function searchSpotify(trackName: string, trackArtist: string): Promise<any> {
   if (!trackName && !trackArtist) {
     return [];

--- a/the-modern-jukebox-react-app/src/hooks/spotify.tsx
+++ b/the-modern-jukebox-react-app/src/hooks/spotify.tsx
@@ -77,4 +77,58 @@ export const getTrackFromUri = async (uri: string) => {
   }
 };
 
+export async function searchSpotify(searchTerm: string): Promise<any[]> {
+  if(!searchTerm) {
+      return [];
+  }
+
+  // get user token
+  let token = (sessionStorage.getItem("token")|| "")
+
+  // get data with axios
+  const {data} = await axios.get("https://api.spotify.com/v1/search",{
+      headers:{
+        Authorization:`Bearer ${token}`
+      },
+      params:{
+        q:searchTerm,
+        limit:6,
+        type: "track"
+      }
+  })
+
+  const mappedData = data.tracks.items.map(
+    (track: {
+      name: "";
+      uri: "";
+      duration_ms: "";
+      album: {
+        name: "";
+        artists: [
+          {
+            name: "";
+          }
+        ];
+        images: [
+          {
+            url: "";
+          }
+        ];
+      };
+    }) => {
+      return {
+        name: track.name,
+        uri: track.uri,
+        duration_ms: track.duration_ms,
+        images: track.album.images[0].url,
+        albumName: track.album.name,
+        artistName: track.album.artists[0].name,
+      };
+    }
+  ) || {};
+
+  return mappedData;
+
+}
+
 export {}

--- a/the-modern-jukebox-react-app/src/hooks/spotify.tsx
+++ b/the-modern-jukebox-react-app/src/hooks/spotify.tsx
@@ -85,8 +85,6 @@ export async function searchSpotify(trackName: string, trackArtist: string): Pro
   // get user token
   let token = sessionStorage.getItem("token") || "";
 
-  console.log("token", token)
-
   // define req url
   const url = `https://api.spotify.com/v1/search?q=${encodeURIComponent(`track:${trackName} artist:${trackArtist}`)}&type=track`;
 
@@ -104,9 +102,9 @@ export async function searchSpotify(trackName: string, trackArtist: string): Pro
 
     // get the response data
     const responseData = await response.json();
-    const tracks = responseData.tracks.hits.map((hit: any) => hit.track);
-    console.log('Spotify search results:', tracks);
-    return tracks;
+    const track = responseData.tracks.items[0];
+    console.log('Spotify search result:', track);
+    return [track];
   } catch (error) {
     // log any errors
     console.error('Error during Spotify search:', error);

--- a/the-modern-jukebox-react-app/src/hooks/spotify.tsx
+++ b/the-modern-jukebox-react-app/src/hooks/spotify.tsx
@@ -85,8 +85,10 @@ export async function searchSpotify(trackName: string, trackArtist: string): Pro
   // get user token
   let token = sessionStorage.getItem("token") || "";
 
+  console.log("token", token)
+
   // define req url
-  const url = `https://api.spotify.com/v1/search?q=${encodeURIComponent(`remaster track:${trackName} artist:${trackArtist}`)}&type=track`;
+  const url = `https://api.spotify.com/v1/search?q=${encodeURIComponent(`track:${trackName} artist:${trackArtist}`)}&type=track`;
 
   // define options
   const options = {

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -12,6 +12,14 @@ import { motion } from "framer-motion";
 import locked from "../../assets/images/locked.png";
 import { SparklesIcon } from "@heroicons/react/24/solid";
 import { searchShazam } from '../../hooks/shazam';
+import { useRef } from "react";
+
+
+// define an inputRef variable
+const inputRef = React.createRef<HTMLInputElement>();
+
+// define a variable of type any
+let shazamSearchResults: any = [];
 
 type Props = {
   setSelectedPage: (value: SelectedPage) => void;
@@ -36,8 +44,30 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
     addToQueue(queueObject);
   }
 
-  function FindSpotifyUri(trackName: string, trackArtist: string) : string{
+  function FormatTrack(track: any): any {
+    return {
+      track: {
+        name: track.name,
+        uri: track.uri,
+        duration_ms: track.duration_ms,
+        album: {
+          name: track.album.name,
+          images: [
+            {
+              url: track.album.images[0].url,
+            },
+          ],
+        },
+      },
+    };
+  }
+
+  function FindSpotifyUriAndExport(trackName: string, trackArtist: string) {
     
+    // search spotify using the trackName and trackArtist
+    const track = FormatTrack(searchSongs(trackName + " " + trackArtist))
+
+    ExportToQueue(track.duration_ms,track.uri, track.name, track.artistName, track.images)
   }
 
   const [quickSearch, setQuickSearch] = useState("");
@@ -105,7 +135,6 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
       
   }
 
-  console.log(songs);
   return (
     <section id="musicplayer" className="gap-16 bg-primary-100 py-10 md:h-full md:pb-0">
     <motion.div
@@ -139,15 +168,15 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
             </p>
             <SparklesIcon className="h-6 w-6 text-white" />
           </div>  
-          <div className="mt-10">    
-          <form onSubmit={() => searchShazam(quickSearch)}>
+          <div className="mt-10">  
+          <form>
             <div className="flex items-center gap-8">
-              <input className="rounded-md bg-gray-100 px-10 py-2 text-black" type='text' onChange={e => setQuickSearch(e.target.value)} />
-              <button className="rounded-md bg-primary-500 px-10 py-2 hover:bg-primary-700" type='submit'>Search</button>
+              <input className="rounded-md bg-gray-100 px-10 py-2 text-black" type='text' ref={inputRef} />
+              <button className="rounded-md bg-primary-500 px-10 py-2 hover:bg-primary-700" type='submit' onClick={() => shazamSearchResults = searchShazam(inputRef.current?.value)}>Search</button>
             </div>
             <div className="flex flex-col mt-8">
               <div className="grid gap-4 grid-cols-6">
-                {songs.map((track: {
+                {Array.isArray(shazamSearchResults) && shazamSearchResults.map((track: {
                   track: {
                     title: string;
                     subtitle: string;
@@ -162,7 +191,7 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
                       <p>
                         {track.track.title} by {track.track.subtitle}
                       </p>
-                      <button className="rounded-md bg-primary-500 px-2 py-2 hover:bg-primary-700" type='submit' onClick={() => FindSpotifyUri(track.track.title, track.track.subtitle)}>
+                      <button className="rounded-md bg-primary-500 px-2 py-2 hover:bg-primary-700" type='submit' onClick={() => FindSpotifyUriAndExport(track.track.title, track.track.subtitle)}>
                         Add To Queue
                       </button>
                     </div>

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -172,31 +172,21 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
           <form>
             <div className="flex items-center gap-8">
               <input className="rounded-md bg-gray-100 px-10 py-2 text-black" type='text' ref={inputRef} />
-              <button className="rounded-md bg-primary-500 px-10 py-2 hover:bg-primary-700" type='submit' onClick={() => shazamSearchResults = searchShazam(inputRef.current?.value)}>Search</button>
+              <button className="rounded-md bg-primary-500 px-10 py-2 hover:bg-primary-700" type='submit' onClick={() => console.log(shazamSearchResults = searchShazam(inputRef.current?.value))}>Search</button>
             </div>
             <div className="flex flex-col mt-8">
               <div className="grid gap-4 grid-cols-6">
-                {Array.isArray(shazamSearchResults) && shazamSearchResults.map((track: {
-                  track: {
-                    title: string;
-                    subtitle: string;
-                    images: {
-                      coverart: string;
-                    };
-                  };
-                }) => {
-                  return (
-                    <div>
-                      <img src={track.track.images.coverart} alt={track.track.title} />
-                      <p>
-                        {track.track.title} by {track.track.subtitle}
-                      </p>
-                      <button className="rounded-md bg-primary-500 px-2 py-2 hover:bg-primary-700" type='submit' onClick={() => FindSpotifyUriAndExport(track.track.title, track.track.subtitle)}>
-                        Add To Queue
-                      </button>
-                    </div>
-                  );
-                })}
+                {shazamSearchResults.map((track: any) => (
+                  <div key={track.track.id}>
+                    <img src={track.track.images.coverart} alt={track.track.title} />
+                    <p>
+                      {track.track.title} by {track.track.subtitle}
+                    </p>
+                    <button className="rounded-md bg-primary-500 px-2 py-2 hover:bg-primary-700" type="submit" onClick={() => FindSpotifyUriAndExport(track.track.title, track.track.subtitle)}>
+                      Add To Queue
+                    </button>
+                  </div>
+                ))}
               </div>
             </div>
           </form>

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -11,6 +11,7 @@ import AnchorLink from "react-anchor-link-smooth-scroll";
 import { motion } from "framer-motion";
 import locked from "../../assets/images/locked.png";
 import { SparklesIcon } from "@heroicons/react/24/solid";
+import { searchShazam } from '../../hooks/shazam';
 
 type Props = {
   setSelectedPage: (value: SelectedPage) => void;
@@ -33,6 +34,10 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
 
     // post the variable to the hardware
     addToQueue(queueObject);
+  }
+
+  function FindSpotifyUri(trackName: string, trackArtist: string) : string{
+    
   }
 
   const [quickSearch, setQuickSearch] = useState("");
@@ -99,6 +104,7 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
       );
       
   }
+
   console.log(songs);
   return (
     <section id="musicplayer" className="gap-16 bg-primary-100 py-10 md:h-full md:pb-0">
@@ -134,36 +140,35 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
             <SparklesIcon className="h-6 w-6 text-white" />
           </div>  
           <div className="mt-10">    
-          <form onSubmit={searchSongs}>
+          <form onSubmit={() => searchShazam(quickSearch)}>
             <div className="flex items-center gap-8">
-            <input className="rounded-md bg-gray-100 px-10 py-2 text-black" type='text' onChange={e => setQuickSearch(e.target.value)} />
-            <button className="rounded-md bg-primary-500 px-10 py-2 hover:bg-primary-700"
-            type='submit'>Search</button>
+              <input className="rounded-md bg-gray-100 px-10 py-2 text-black" type='text' onChange={e => setQuickSearch(e.target.value)} />
+              <button className="rounded-md bg-primary-500 px-10 py-2 hover:bg-primary-700" type='submit'>Search</button>
             </div>
             <div className="flex flex-col mt-8">
-            <div className="grid gap-4 grid-cols-6">  
-            {songs.map((track: {
-                name: '',
-                duration_ms: '',
-                artistName: '',
-                images:''
-                uri: ''
-              }) => {
+              <div className="grid gap-4 grid-cols-6">
+                {songs.map((track: {
+                  track: {
+                    title: string;
+                    subtitle: string;
+                    images: {
+                      coverart: string;
+                    };
+                  };
+                }) => {
                   return (
-                        <div>
-                          <img src={track.images} />
-                          <p>
-                            {track.name} by {track.artistName}
-                          </p>
-                          <button  className="rounded-md bg-primary-500 px-2 py-2 hover:bg-primary-700"
-                          type='submit' onClick={() => ExportToQueue(track.duration_ms,track.uri, track.name, track.artistName, track.images)}>
-                          Add To Queue
-                          </button>
-                        </div>
-
-                  )
-              })}
-            </div>
+                    <div>
+                      <img src={track.track.images.coverart} alt={track.track.title} />
+                      <p>
+                        {track.track.title} by {track.track.subtitle}
+                      </p>
+                      <button className="rounded-md bg-primary-500 px-2 py-2 hover:bg-primary-700" type='submit' onClick={() => FindSpotifyUri(track.track.title, track.track.subtitle)}>
+                        Add To Queue
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
             </div>
           </form>
           </div>

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef} from 'react';
+import { useState, useRef, useEffect} from 'react';
 import { QueueObject } from '../../types';
 import { addToQueue } from '../../services/SpotifyPostService';
 import useMediaQuery from '../../hooks/useMediaQuery';
@@ -36,25 +36,6 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
     addToQueue(queueObject);
   }
 
-  // function used to format an item as a queue item
-  function FormatTrack(track: any): any {
-    return {
-      track: {
-        name: track.name,
-        uri: track.uri,
-        duration_ms: track.duration_ms,
-        album: {
-          name: track.album.name,
-          images: [
-            {
-              url: track.album.images[0].url,
-            },
-          ],
-        },
-      },
-    };
-  }
-
   // useState setup for the Shazam search
   const [shazamSearchResults, setShazamSearchResults] = useState<any[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -72,18 +53,26 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
   };
 
   // useState setup for Spotify search
-  const [spotifySearchResult, setSpotifySearchResult] = useState<any[]>([]);
+  const [spotifySearchResult, setSpotifySearchResult] = useState<any>();
+
+  // useEffect to format the track when spotifySearchResult changes
+  useEffect(() => {
+    if (spotifySearchResult) {
+      ExportToQueue(
+        spotifySearchResult.duration_ms,
+        spotifySearchResult.uri,
+        spotifySearchResult.name,
+        spotifySearchResult.artists[0].name,
+        spotifySearchResult.album.images[0]
+      );
+    }
+  }, [spotifySearchResult]);
 
   // function to call spotify search
   const FindSpotifyUriAndExport = async (trackName: string, trackArtist: string) => {
-
     // search for song
     const result = await searchSpotify(trackName, trackArtist);
     setSpotifySearchResult(result);
-    
-    // format the track then queue it
-    const trackToQueue = FormatTrack(spotifySearchResult)
-    ExportToQueue(trackToQueue.duration_ms, trackToQueue.uri, trackToQueue.name, trackToQueue.artistName, trackToQueue.images)
   };
 
   return (

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -61,21 +61,30 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
   // useState setup for the Shazam search
   const [shazamSearchResults, setShazamSearchResults] = useState<any[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // function to call search
   const handleSearch = async () => {
+    // verify there is data in the textbox
     if (inputRef.current && typeof inputRef.current !== "undefined") {
+      // set search results var
       const results = await searchShazam(inputRef.current.value);
       setShazamSearchResults(results);
     }
   };
 
   // useState setup for Spotify search
-  const [spotifySearchResults, setSpotifySearchResults] = useState<any[]>([]);
+  const [spotifySearchResult, setSpotifySearchResult] = useState<any[]>([]);
+
+  // function to call spotify search
   const FindSpotifyUriAndExport = async (trackName: string, trackArtist: string) => {
-    const results = await searchSpotify(trackName, trackArtist);
-    setSpotifySearchResults(results);
+
+    // search for song
+    const result = await searchSpotify(trackName, trackArtist);
+    setSpotifySearchResult(result);
     
-    const trackToQueue = FormatTrack(spotifySearchResults[0])
-    ExportToQueue(trackToQueue.duration_ms,trackToQueue.uri, trackToQueue.name, trackToQueue.artistName, trackToQueue.images)
+    // format the track then queue it
+    const trackToQueue = FormatTrack(spotifySearchResult)
+    ExportToQueue(trackToQueue.duration_ms, trackToQueue.uri, trackToQueue.name, trackToQueue.artistName, trackToQueue.images)
   };
 
   const [quickSearch, setQuickSearch] = useState("");

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -122,9 +122,11 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
                     <p>
                       {track.title} by {track.subtitle}
                     </p>
-                    <button className="rounded-md bg-primary-500 px-2 py-2 hover:bg-primary-700" type="submit" onClick={() => FindSpotifyUriAndExport(track.title, track.subtitle)}>
-                      Add To Queue
-                    </button>
+                    {token && (
+                      <button className="rounded-md bg-primary-500 px-2 py-2 hover:bg-primary-700" type="submit" onClick={() => FindSpotifyUriAndExport(track.title, track.subtitle)}>
+                        Add To Queue
+                      </button>
+                    )}
                   </div>
                 ))}
               </div>

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -63,7 +63,7 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
         spotifySearchResult.uri,
         spotifySearchResult.name,
         spotifySearchResult.artists[0].name,
-        spotifySearchResult.album.images[0]
+        spotifySearchResult.album.images[0].url
       );
     }
   }, [spotifySearchResult]);

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -71,7 +71,7 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
   // useState setup for Spotify search
   const [spotifySearchResults, setSpotifySearchResults] = useState<any[]>([]);
   const FindSpotifyUriAndExport = async (trackName: string, trackArtist: string) => {
-    const results = await searchSpotify(trackName + " " + trackArtist);
+    const results = await searchSpotify(trackName, trackArtist);
     setSpotifySearchResults(results);
     
     const trackToQueue = FormatTrack(spotifySearchResults[0])

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -1,13 +1,8 @@
-import {useEffect, useState, useRef} from 'react';
-import { getTokenFromUrl } from '../../hooks/spotify';
-import { SpotifyApi } from '@spotify/web-api-ts-sdk';
+import { useState, useRef} from 'react';
 import { QueueObject } from '../../types';
 import { addToQueue } from '../../services/SpotifyPostService';
-import axios from 'axios';
-import React from 'react';
 import useMediaQuery from '../../hooks/useMediaQuery';
 import { SelectedPage } from '../../assets/variables/availablepages';
-import AnchorLink from "react-anchor-link-smooth-scroll";
 import { motion } from "framer-motion";
 import locked from "../../assets/images/locked.png";
 import { SparklesIcon } from "@heroicons/react/24/solid";
@@ -19,6 +14,8 @@ type Props = {
 };
 
 const MusicPlayer = ({ setSelectedPage }: Props) => {
+
+  // basic component setu[]
   const isAboveMediumScreens = useMediaQuery("(min-width:1060px)");
   let token = (sessionStorage.getItem("token")|| "")
 
@@ -64,8 +61,10 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
 
   // function to call search
   const handleSearch = async () => {
+    
     // verify there is data in the textbox
     if (inputRef.current && typeof inputRef.current !== "undefined") {
+      
       // set search results var
       const results = await searchShazam(inputRef.current.value);
       setShazamSearchResults(results);
@@ -86,71 +85,6 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
     const trackToQueue = FormatTrack(spotifySearchResult)
     ExportToQueue(trackToQueue.duration_ms, trackToQueue.uri, trackToQueue.name, trackToQueue.artistName, trackToQueue.images)
   };
-
-  const [quickSearch, setQuickSearch] = useState("");
-  interface s {
-    track: {
-      name: "";
-      uri: "";
-      duration_ms:"";
-      album:{
-        name: "";
-        images: [
-          {
-            url: "";
-          }
-        ];
-      };
-    };
-   }
-  const [songs, setSongs] = useState([]);
-  
-  const searchSongs = async (e: any) => {
-    e.preventDefault()
-    const {data} = await axios.get("https://api.spotify.com/v1/search",{
-      headers:{
-        Authorization:`Bearer ${token}`
-      },
-      params:{
-        q:quickSearch,
-        limit:6,
-        type: "track"
-      }
-    }) 
-    console.log(data);
-    setSongs(
-      data.tracks.items.map(
-        (track: {
-          name: "";
-          uri: "";
-          duration_ms:"";
-          album:{
-            name: "";
-            artists: [
-              {
-                name: "";
-              }
-            ];
-            images: [
-              {
-                url: "";
-              }
-            ];
-          };
-        }) => {
-          return {
-            name: track.name,
-            uri: track.uri,
-            duration_ms: track.duration_ms,
-            images: track.album.images[0].url,
-            albumName: track.album.name,
-            artistName: track.album.artists[0].name,
-          };
-        }
-      )|| {}
-      );
-      
-  }
 
   return (
     <section id="musicplayer" className="gap-16 bg-primary-100 py-10 md:h-full md:pb-0">

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useState, useRef} from 'react';
 import { getTokenFromUrl } from '../../hooks/spotify';
 import { SpotifyApi } from '@spotify/web-api-ts-sdk';
 import { QueueObject } from '../../types';
@@ -12,14 +12,18 @@ import { motion } from "framer-motion";
 import locked from "../../assets/images/locked.png";
 import { SparklesIcon } from "@heroicons/react/24/solid";
 import { searchShazam } from '../../hooks/shazam';
-import { useRef } from "react";
 
 
-// define an inputRef variable
-const inputRef = React.createRef<HTMLInputElement>();
+const [shazamSearchResults, setShazamSearchResults] = useState<any[]>([]);
+const inputRef = useRef<HTMLInputElement>(null);
 
-// define a variable of type any
-let shazamSearchResults: any = [];
+const handleSearch = async () => {
+  if (inputRef.current && typeof inputRef.current !== "undefined") {
+    const results = await searchShazam(inputRef.current.value);
+    setShazamSearchResults(results);
+  }
+};
+
 
 type Props = {
   setSelectedPage: (value: SelectedPage) => void;
@@ -165,14 +169,14 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
             <SparklesIcon className="h-6 w-6 text-white" />
             <p className="text-lg">
               Search and queue your favorite songs
-            </p>
+            </p> 
             <SparklesIcon className="h-6 w-6 text-white" />
           </div>  
           <div className="mt-10">  
           <form>
             <div className="flex items-center gap-8">
               <input className="rounded-md bg-gray-100 px-10 py-2 text-black" type='text' ref={inputRef} />
-              <button className="rounded-md bg-primary-500 px-10 py-2 hover:bg-primary-700" type='submit' onClick={() => console.log(shazamSearchResults = searchShazam(inputRef.current?.value))}>Search</button>
+              <button className="rounded-md bg-primary-500 px-10 py-2 hover:bg-primary-700" type='submit' onClick={handleSearch}>Search</button>
             </div>
             <div className="flex flex-col mt-8">
               <div className="grid gap-4 grid-cols-6">

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -176,15 +176,15 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
               <input className="rounded-md bg-gray-100 px-10 py-2 text-black" type='text' ref={inputRef} />
               <button className="rounded-md bg-primary-500 px-10 py-2 hover:bg-primary-700" type='submit' onClick={handleSearch}>Search</button>
             </div>
-            <div className="flex flex-col mt-8">
+            <div className="flex flex-col mt-8"> 
               <div className="grid gap-4 grid-cols-6">
                 {shazamSearchResults.map((track: any) => (
-                  <div key={track.track.id}>
-                    <img src={track.track.images.coverart} alt={track.track.title} />
+                  <div key={track.id}>
+                    <img src={track.images.coverart} alt={track.title} />
                     <p>
-                      {track.track.title} by {track.track.subtitle}
+                      {track.title} by {track.subtitle}
                     </p>
-                    <button className="rounded-md bg-primary-500 px-2 py-2 hover:bg-primary-700" type="submit" onClick={() => FindSpotifyUriAndExport(track.track.title, track.track.subtitle)}>
+                    <button className="rounded-md bg-primary-500 px-2 py-2 hover:bg-primary-700" type="submit" onClick={() => FindSpotifyUriAndExport(track.title, track.subtitle)}>
                       Add To Queue
                     </button>
                   </div>

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -30,7 +30,7 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
       trackArtist: trackArtist,
       trackCover: trackCover,
     };
-    console.log("What is Posted:", queueObject);
+    // console.log("What is Posted:", queueObject);
 
     // post the variable to the hardware
     addToQueue(queueObject);

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -13,18 +13,6 @@ import locked from "../../assets/images/locked.png";
 import { SparklesIcon } from "@heroicons/react/24/solid";
 import { searchShazam } from '../../hooks/shazam';
 
-
-const [shazamSearchResults, setShazamSearchResults] = useState<any[]>([]);
-const inputRef = useRef<HTMLInputElement>(null);
-
-const handleSearch = async () => {
-  if (inputRef.current && typeof inputRef.current !== "undefined") {
-    const results = await searchShazam(inputRef.current.value);
-    setShazamSearchResults(results);
-  }
-};
-
-
 type Props = {
   setSelectedPage: (value: SelectedPage) => void;
 };
@@ -47,6 +35,16 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
     // post the variable to the hardware
     addToQueue(queueObject);
   }
+
+  const [shazamSearchResults, setShazamSearchResults] = useState<any[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleSearch = async () => {
+    if (inputRef.current && typeof inputRef.current !== "undefined") {
+      const results = await searchShazam(inputRef.current.value);
+      setShazamSearchResults(results);
+    }
+  };
 
   function FormatTrack(track: any): any {
     return {

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -12,6 +12,7 @@ import { motion } from "framer-motion";
 import locked from "../../assets/images/locked.png";
 import { SparklesIcon } from "@heroicons/react/24/solid";
 import { searchShazam } from '../../hooks/shazam';
+import { searchSpotify } from '../../hooks/spotify';
 
 type Props = {
   setSelectedPage: (value: SelectedPage) => void;
@@ -20,6 +21,8 @@ type Props = {
 const MusicPlayer = ({ setSelectedPage }: Props) => {
   const isAboveMediumScreens = useMediaQuery("(min-width:1060px)");
   let token = (sessionStorage.getItem("token")|| "")
+
+  // function used to export to queue for the hardware
   function ExportToQueue(duration_ms: string, trackUri: string, tackName: string, trackArtist: string, trackCover: string) {
     // create a variable of type QueueObject that is made with the uri and the token
     const queueObject: QueueObject = {
@@ -36,16 +39,7 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
     addToQueue(queueObject);
   }
 
-  const [shazamSearchResults, setShazamSearchResults] = useState<any[]>([]);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const handleSearch = async () => {
-    if (inputRef.current && typeof inputRef.current !== "undefined") {
-      const results = await searchShazam(inputRef.current.value);
-      setShazamSearchResults(results);
-    }
-  };
-
+  // function used to format an item as a queue item
   function FormatTrack(track: any): any {
     return {
       track: {
@@ -64,13 +58,25 @@ const MusicPlayer = ({ setSelectedPage }: Props) => {
     };
   }
 
-  function FindSpotifyUriAndExport(trackName: string, trackArtist: string) {
-    
-    // search spotify using the trackName and trackArtist
-    const track = FormatTrack(searchSongs(trackName + " " + trackArtist))
+  // useState setup for the Shazam search
+  const [shazamSearchResults, setShazamSearchResults] = useState<any[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const handleSearch = async () => {
+    if (inputRef.current && typeof inputRef.current !== "undefined") {
+      const results = await searchShazam(inputRef.current.value);
+      setShazamSearchResults(results);
+    }
+  };
 
-    ExportToQueue(track.duration_ms,track.uri, track.name, track.artistName, track.images)
-  }
+  // useState setup for Spotify search
+  const [spotifySearchResults, setSpotifySearchResults] = useState<any[]>([]);
+  const FindSpotifyUriAndExport = async (trackName: string, trackArtist: string) => {
+    const results = await searchSpotify(trackName + " " + trackArtist);
+    setSpotifySearchResults(results);
+    
+    const trackToQueue = FormatTrack(spotifySearchResults[0])
+    ExportToQueue(trackToQueue.duration_ms,trackToQueue.uri, trackToQueue.name, trackToQueue.artistName, trackToQueue.images)
+  };
 
   const [quickSearch, setQuickSearch] = useState("");
   interface s {


### PR DESCRIPTION
The search now runs through the Shazam API and when you queue it uses the spotify API to get the URI and everything for the queue data.

[DEMO VIDEO HERE](https://drive.google.com/file/d/1lfP0D3gL87SKw0xFuCF0nl4_zCsDlK-K/view?usp=sharing)

**KNOWN ISSUE:**  When selecting the "Search" or "Add to Queue" buttons it jumps to the top of the page, bit I figured that shouldn't be an issue once we separate the pages, and if it is then it will require different fix then anyways

closes #50
closes #54