### PR TITLE
New endpoints

### DIFF
--- a/the-modern-jukebox-react-app/api/index.js
+++ b/the-modern-jukebox-react-app/api/index.js
@@ -5,26 +5,27 @@ const cors = require('cors');
 const app = express();
 const port = process.env.PORT || 8080; // Use the assigned port or default to 8080
 
-let messages = [];
+let queueMessages = [];
+let playingMessages = [];
 
 app.use(bodyParser.json());
 app.use(cors());
 
-// ednpoint to get the queue
+// endpoint to get the queue
 app.get('/api/queue', (req, res) => {
   res.setHeader('Content-Type', 'text/html');
   res.setHeader('Cache-Control', 's-max-age=1, stale-while-revalidate');
-  res.json(messages);
+  res.json(queueMessages);
 });
 
 app.delete('/api/queue', (req, res) => {
-  messages = [];
+  queueMessages = [];
   res.send('Queue cleared successfully!');
 });
 
 app.post('/api/addQueue', (req, res) => {
   const { message } = req.body;
-  messages.push(message);
+  queueMessages.push(message);
   res.header('Access-Control-Allow-Origin', '*');
   res.send('Message received successfully!');
 });
@@ -33,17 +34,17 @@ app.post('/api/addQueue', (req, res) => {
 app.get('/api/playing', (req, res) => {
   res.setHeader('Content-Type', 'text/html');
   res.setHeader('Cache-Control', 's-max-age=1, stale-while-revalidate');
-  res.json(messages);
+  res.json(playingMessages);
 });
 
 app.delete('/api/playing', (req, res) => {
-  messages = [];
-  res.send('Queue cleared successfully!');
+  playingMessages = [];
+  res.send('Playing cleared successfully!');
 });
 
 app.post('/api/addPlaying', (req, res) => {
   const { message } = req.body;
-  messages.push(message);
+  playingMessages.push(message);
   res.header('Access-Control-Allow-Origin', '*');
   res.send('Message received successfully!');
 });

--- a/the-modern-jukebox-react-app/api/index.js
+++ b/the-modern-jukebox-react-app/api/index.js
@@ -10,6 +10,7 @@ let messages = [];
 app.use(bodyParser.json());
 app.use(cors());
 
+// ednpoint to get the queue
 app.get('/api/queue', (req, res) => {
   res.setHeader('Content-Type', 'text/html');
   res.setHeader('Cache-Control', 's-max-age=1, stale-while-revalidate');
@@ -35,6 +36,19 @@ app.get('/api/playing', (req, res) => {
   res.json(messages);
 });
 
+app.delete('/api/playing', (req, res) => {
+  messages = [];
+  res.send('Queue cleared successfully!');
+});
+
+app.post('/api/addPlaying', (req, res) => {
+  const { message } = req.body;
+  messages.push(message);
+  res.header('Access-Control-Allow-Origin', '*');
+  res.send('Message received successfully!');
+});
+
+// listening on 8080 port
 app.listen(port, () => {
   console.log(`Server listening at port ${port}`);
 });

--- a/the-modern-jukebox-react-app/api/index.js
+++ b/the-modern-jukebox-react-app/api/index.js
@@ -7,6 +7,7 @@ const port = process.env.PORT || 8080; // Use the assigned port or default to 80
 
 let queueMessages = [];
 let playingMessages = [];
+let controlsMessages = [];
 
 app.use(bodyParser.json());
 app.use(cors());
@@ -34,7 +35,11 @@ app.post('/api/addQueue', (req, res) => {
 app.get('/api/playing', (req, res) => {
   res.setHeader('Content-Type', 'text/html');
   res.setHeader('Cache-Control', 's-max-age=1, stale-while-revalidate');
-  res.json(playingMessages);
+  if (playingMessages.length > 0) {
+    res.json(playingMessages[0]);
+  } else {
+    res.json(null);
+  }
 });
 
 app.delete('/api/playing', (req, res) => {
@@ -44,7 +49,30 @@ app.delete('/api/playing', (req, res) => {
 
 app.post('/api/addPlaying', (req, res) => {
   const { message } = req.body;
-  playingMessages.push(message);
+  playingMessages = [message]; // Replace the existing playing message with the new one
+  res.header('Access-Control-Allow-Origin', '*');
+  res.send('Message received successfully!');
+});
+
+// endpoint to get the control inputs
+app.get('/api/controls', (req, res) => {
+  res.setHeader('Content-Type', 'text/html');
+  res.setHeader('Cache-Control', 's-max-age=1, stale-while-revalidate');
+  if (controlsMessages.length > 0) {
+    res.json(controlsMessages[0]);
+  } else {
+    res.json(null);
+  }
+});
+
+app.delete('/api/controls', (req, res) => {
+  controlsMessages = [];
+  res.send('Controls cleared successfully!');
+});
+
+app.post('/api/addControls', (req, res) => {
+  const { message } = req.body;
+  controlsMessages = [message]; // Replace the existing controls message with the new one
   res.header('Access-Control-Allow-Origin', '*');
   res.send('Message received successfully!');
 });

--- a/the-modern-jukebox-react-app/api/index.js
+++ b/the-modern-jukebox-react-app/api/index.js
@@ -85,7 +85,7 @@ app.get('/api/sessions', (req, res) => {
   res.json(activeSessions);
 });
 
-app.delete('/api/session', (req, res) => {
+app.delete('/api/sessions', (req, res) => {
   activeSessions = [];
   res.send('sessions cleared successfully!');
 });

--- a/the-modern-jukebox-react-app/api/index.js
+++ b/the-modern-jukebox-react-app/api/index.js
@@ -8,6 +8,7 @@ const port = process.env.PORT || 8080; // Use the assigned port or default to 80
 let queueMessages = [];
 let playingMessages = [];
 let controlsMessages = [];
+let activeSessions = [];
 
 app.use(bodyParser.json());
 app.use(cors());
@@ -73,6 +74,25 @@ app.delete('/api/controls', (req, res) => {
 app.post('/api/addControls', (req, res) => {
   const { message } = req.body;
   controlsMessages = [message]; // Replace the existing controls message with the new one
+  res.header('Access-Control-Allow-Origin', '*');
+  res.send('Message received successfully!');
+});
+
+// endpoint to keep track of sessions and tokens
+app.get('/api/sessions', (req, res) => {
+  res.setHeader('Content-Type', 'text/html');
+  res.setHeader('Cache-Control', 's-max-age=1, stale-while-revalidate');
+  res.json(activeSessions);
+});
+
+app.delete('/api/session', (req, res) => {
+  activeSessions = [];
+  res.send('sessions cleared successfully!');
+});
+
+app.post('/api/addSession', (req, res) => {
+  const { message } = req.body;
+  activeSessions.push(message);
   res.header('Access-Control-Allow-Origin', '*');
   res.send('Message received successfully!');
 });

--- a/the-modern-jukebox-react-app/api/index.js
+++ b/the-modern-jukebox-react-app/api/index.js
@@ -28,6 +28,13 @@ app.post('/api/addQueue', (req, res) => {
   res.send('Message received successfully!');
 });
 
+// endpoint to get the current playing song
+app.get('/api/playing', (req, res) => {
+  res.setHeader('Content-Type', 'text/html');
+  res.setHeader('Cache-Control', 's-max-age=1, stale-while-revalidate');
+  res.json(messages);
+});
+
 app.listen(port, () => {
   console.log(`Server listening at port ${port}`);
 });

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -8,6 +8,7 @@ import { SparklesIcon } from "@heroicons/react/24/solid";
 import { searchShazam } from '../../hooks/shazam';
 import { searchSpotify } from '../../hooks/spotify';
 import './index.css';
+import { addToPlaying } from '../../services/PlayingPostService';
 
 function MusicPlayer () {
   const isAboveMediumScreens = useMediaQuery("(min-width:1060px)");
@@ -34,6 +35,7 @@ function MusicPlayer () {
     // console.log("What is Posted:", queueObject);
 
     // post the variable to the hardware
+    addToPlaying(queueObject);
     addToQueue(queueObject);
   }
 

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect} from 'react';
 import { QueueObject } from '../../types';
-import { addToQueue } from '../../services/SpotifyPostService';
+import { addToQueue } from '../../services/QueuePostService';
 import useMediaQuery from '../../hooks/useMediaQuery';
 import { motion } from "framer-motion";
 import locked from "../../assets/images/locked.png";

--- a/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/musicPlayer/index.tsx
@@ -35,7 +35,6 @@ function MusicPlayer () {
     // console.log("What is Posted:", queueObject);
 
     // post the variable to the hardware
-    addToPlaying(queueObject);
     addToQueue(queueObject);
   }
 

--- a/the-modern-jukebox-react-app/src/pages/queue/index.tsx
+++ b/the-modern-jukebox-react-app/src/pages/queue/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { clearQueue } from '../../services/SpotifyPostService';
-import { getQueue } from '../../services/SpotifyPostService';
+import { clearQueue } from '../../services/QueuePostService';
+import { getQueue } from '../../services/QueuePostService';
 import { QueueObject } from '../../types';
 import './index.css';
 import useMediaQuery from '../../hooks/useMediaQuery';

--- a/the-modern-jukebox-react-app/src/services/ControlsPostService.ts
+++ b/the-modern-jukebox-react-app/src/services/ControlsPostService.ts
@@ -1,52 +1,52 @@
-import { QueueObject } from '../types';
+import { Controls } from '../types';
 
 let receieveUrl = '';
 if (window.location.origin.includes('localhost')) {
     // Development environment
-    receieveUrl = 'http://localhost:8080/api/queue';
+    receieveUrl = 'http://localhost:8080/api/controls';
 } else {
     // Production environment
-    receieveUrl = `${window.location.origin}/api/queue`;
+    receieveUrl = `${window.location.origin}/api/controls`;
 }
 
 let sendUrl = '';
 if (window.location.origin.includes('localhost')) {
     // Development environment
-    sendUrl = 'http://localhost:8080/api/addQueue';
+    sendUrl = 'http://localhost:8080/api/addControls';
 } else {
     // Production environment
-    sendUrl = `${window.location.origin}/api/addQueue`;
+    sendUrl = `${window.location.origin}/api/addControls`;
 }
 
-// function that returns QueueObject[] from the queue at the receieveUrl
-export const getQueue = async (): Promise<QueueObject[]> => {
+// function that returns Controls for the controls at the receieveUrl
+export const getControls = async (): Promise<Controls> => {
     try {
         const response = await fetch(receieveUrl);
         const json = await response.json();
-        return json as QueueObject[];
-    } catch (error) {
-        console.error('Error getting queue:', error);
-        return [];
+        return json as Controls;
+    } catch (error) { 
+        console.error('Error getting controls:', error);
+        return {} as Controls;
     }
 };
 
-
-export const addToQueue = async (spotifyObject: QueueObject) => {
+// function to make new control input
+export const addToControls = async (controlInput: Controls) => {
     try {
         await fetch(sendUrl, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
             },
-            body: JSON.stringify({ message: spotifyObject }),
+            body: JSON.stringify({ message: controlInput }),
         });
     } catch (error) {
         console.error('Error sending message:', error);
     }
 };
 
-// function to clear the queue that clears all data stored at receieveUrl
-export const clearQueue = async () => {
+// function to clear the current control inpput
+export const clearControls = async () => {
     try {
         await fetch(receieveUrl, {
             method: 'DELETE',
@@ -55,7 +55,7 @@ export const clearQueue = async () => {
             },
         });
     } catch (error) {
-        console.error('Error clearing queue:', error);
+        console.error('Error clearing now playing:', error);
     }
 };
 

--- a/the-modern-jukebox-react-app/src/services/PlayingPostService.ts
+++ b/the-modern-jukebox-react-app/src/services/PlayingPostService.ts
@@ -1,4 +1,4 @@
-import { QueueObject} from '../types';
+import { QueueObject } from '../types';
 
 
 let receieveUrl = '';

--- a/the-modern-jukebox-react-app/src/services/PlayingPostService.ts
+++ b/the-modern-jukebox-react-app/src/services/PlayingPostService.ts
@@ -1,0 +1,64 @@
+import { QueueObject} from '../types';
+
+
+let receieveUrl = '';
+if (window.location.origin.includes('localhost')) {
+    // Development environment
+    receieveUrl = 'http://localhost:8080/api/playing';
+} else {
+    // Production environment
+    receieveUrl = `${window.location.origin}/api/playing`;
+}
+
+let sendUrl = '';
+if (window.location.origin.includes('localhost')) {
+    // Development environment
+    sendUrl = 'http://localhost:8080/api/addPlaying';
+} else {
+    // Production environment
+    sendUrl = `${window.location.origin}/api/addPlaying`;
+}
+
+// function that returns QueueObject for the song now playing at the receieveUrl
+export const getPlaying = async (): Promise<QueueObject> => {
+    try {
+        const response = await fetch(receieveUrl);
+        const json = await response.json();
+        return json as QueueObject;
+    } catch (error) { 
+        console.error('Error getting currently playing:', error);
+        return {} as QueueObject;
+    }
+};
+
+
+export const addToPlaying = async (spotifyObject: QueueObject) => {
+    try {
+        await fetch(sendUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ message: spotifyObject }),
+        });
+    } catch (error) {
+        console.error('Error sending message:', error);
+    }
+};
+
+// function to clear the currently playing song
+export const clearPlaying = async () => {
+    try {
+        await fetch(receieveUrl, {
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+    } catch (error) {
+        console.error('Error clearing now playing:', error);
+    }
+};
+
+
+

--- a/the-modern-jukebox-react-app/src/services/QueuePostService.ts
+++ b/the-modern-jukebox-react-app/src/services/QueuePostService.ts
@@ -1,4 +1,3 @@
-import React, { useEffect, useState } from 'react';
 import { QueueObject} from '../types';
 
 

--- a/the-modern-jukebox-react-app/src/services/SessionsPostService.ts
+++ b/the-modern-jukebox-react-app/src/services/SessionsPostService.ts
@@ -1,0 +1,63 @@
+import { Session } from '../types';
+
+let receieveUrl = '';
+if (window.location.origin.includes('localhost')) {
+    // Development environment
+    receieveUrl = 'http://localhost:8080/api/sessions';
+} else {
+    // Production environment
+    receieveUrl = `${window.location.origin}/api/sessions`;
+}
+
+let sendUrl = '';
+if (window.location.origin.includes('localhost')) {
+    // Development environment
+    sendUrl = 'http://localhost:8080/api/addSession';
+} else {
+    // Production environment
+    sendUrl = `${window.location.origin}/api/addSession`;
+}
+
+// function that returns Session[] from the list of active sessions at the receieveUrl
+export const getSessions = async (): Promise<Session[]> => {
+    try {
+        const response = await fetch(receieveUrl);
+        const json = await response.json();
+        return json as Session[];
+    } catch (error) {
+        console.error('Error getting sessions:', error);
+        return [];
+    }
+};
+
+// function used to add a new session to the list of active sessions at the sendUrl
+export const addNewSession = async (newSession: Session) => {
+    try {
+        await fetch(sendUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ message: newSession }),
+        });
+    } catch (error) {
+        console.error('Error adding session:', error);
+    }
+};
+
+// function to delete all sessions
+export const deleteAllSessions = async () => {
+    try {
+        await fetch(receieveUrl, {
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+    } catch (error) {
+        console.error('Error clearing sessions:', error);
+    }
+};
+
+
+

--- a/the-modern-jukebox-react-app/src/types.ts
+++ b/the-modern-jukebox-react-app/src/types.ts
@@ -13,3 +13,8 @@ export type Controls = {
     next: boolean;
     previous: boolean;
 }
+
+export type Session = {
+    session_id: string;     // our generated session id
+    token: string;          // token used by the spotify api
+}

--- a/the-modern-jukebox-react-app/src/types.ts
+++ b/the-modern-jukebox-react-app/src/types.ts
@@ -6,3 +6,10 @@ export type QueueObject = {
     trackArtist: string;
     trackCover: string;
 }
+
+export type Controls = {
+    play: boolean;
+    pause: boolean;
+    next: boolean;
+    previous: boolean;
+}


### PR DESCRIPTION
 `/api/playing`
- holds ONE queue object (same type we use for the queue), which can be added by the hardware when a song starts playing
- is used to display what’s currently playing on the web app
- when you add a new object it automatically removes the old one

`/api/controls` 
- holds ONE controls object, which ideally software and hardware will both be listening for a post to there, then react accordingly 
- we can wait until the Beta to actually implement that one.


closes #65 
closes #67 